### PR TITLE
Checkpoint older modules written by Ansible

### DIFF
--- a/plugins/modules/checkpoint_run_script.py
+++ b/plugins/modules/checkpoint_run_script.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_run_script
+short_description: Run scripts on Check Point devices over Web Services API
+description:
+- Run scripts on Check Point devices. All operations are performed over Web Services
+  API.
+version_added: "2.7"
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  script_name:
+    description:
+    - Name of the script.
+    type: str
+    required: true
+  script:
+    description:
+    - Script body contents.
+    type: str
+    required: true
+  targets:
+    description:
+    - Targets the script should be run against. Can reference either name or UID.
+    type: list
+    required: true
+"""
+
+EXAMPLES = """
+- name: Run script
+  checkpoint_run_script:
+    script_name: "List root"
+    script: ls -l /
+    targets:
+      - mycheckpointgw
+"""
+
+RETURN = """
+checkpoint_run_script:
+  description: The checkpoint run script output.
+  returned: always.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def run_script(module, connection):
+    script_name = module.params["script_name"]
+    script = module.params["script"]
+    targets = module.params["targets"]
+
+    payload = {
+        "script-name": script_name,
+        "script": script,
+        "targets": targets,
+    }
+
+    code, response = connection.send_request("/web_api/run-script", payload)
+
+    return code, response
+
+
+def main():
+    argument_spec = dict(
+        script_name=dict(type="str", required=True),
+        script=dict(type="str", required=True),
+        targets=dict(type="list", required=True),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+    code, response = run_script(module, connection)
+    result = {"changed": True}
+
+    if code == 200:
+        result["checkpoint_run_script"] = response
+    else:
+        module.fail_json(
+            msg="Checkpoint device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_session.py
+++ b/plugins/modules/checkpoint_session.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_session
+short_description: Manages session objects on Check Point over Web Services API
+description:
+- Manages session objects on Check Point devices performing actions like publish and
+  discard. All operations are performed over Web Services API.
+version_added: "2.7"
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  uid:
+    description:
+    - UID of the session.
+    type: str
+    required: true
+  state:
+    description:
+    - Action to perform on the session object. Valid choices are published and discarded.
+    type: str
+    choices:
+    - published
+    - discarded
+    default: published
+"""
+
+EXAMPLES = """
+- name: Publish session
+  checkpoint_session:
+    uid: 7a13a360-9b24-40d7-acd3-5b50247be33e
+    state: published
+
+- name: Discard session
+  checkpoint_session:
+    uid: 7a13a360-9b24-40d7-acd3-5b50247be33e
+    state: discarded
+"""
+
+RETURN = """
+checkpoint_session:
+  description: The checkpoint session output per return from API. It will differ depending on action.
+  returned: always.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def get_session(module, connection):
+    payload = {"uid": module.params["uid"]}
+
+    code, result = connection.send_request("/web_api/show-session", payload)
+
+    return code, result
+
+
+def main():
+    argument_spec = dict(
+        uid=dict(type="str", default=None),
+        state=dict(
+            type="str", default="published", choices=["published", "discarded"]
+        ),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+    code, response = get_session(module, connection)
+    result = {"changed": False}
+
+    if code == 200:
+        result["changed"] = True
+        payload = None
+
+        if module.params["uid"]:
+            payload = {"uid": module.params["uid"]}
+
+        if module.params["state"] == "published":
+            code, response = connection.send_request(
+                "/web_api/publish", payload
+            )
+        else:
+            code, response = connection.send_request(
+                "/web_api/discard", payload
+            )
+        if code != 200:
+            module.fail_json(msg=response)
+        result["checkpoint_session"] = response
+    else:
+        module.fail_json(
+            msg="Check Point device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_task_facts.py
+++ b/plugins/modules/checkpoint_task_facts.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_task_facts
+short_description: Get task objects facts on Check Point over Web Services API
+description:
+- Get task objects facts on Check Point devices. All operations are performed over
+  Web Services API.
+version_added: "2.7"
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  task_id:
+    description:
+    - ID of the task object.
+    type: str
+    required: true
+"""
+
+EXAMPLES = """
+- name: Get task facts
+  checkpoint_task_facts:
+    task_id: 2eec70e5-78a8-4bdb-9a76-cfb5601d0bcb
+"""
+
+RETURN = """
+ansible_facts:
+  description: The checkpoint task facts.
+  returned: always.
+  type: list
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def get_task(module, connection):
+    task_id = module.params["task_id"]
+
+    if task_id:
+        payload = {"task-id": task_id, "details-level": "full"}
+
+        code, response = connection.send_request("/web_api/show-task", payload)
+    else:
+        code, response = connection.send_request("/web_api/show-tasks", None)
+
+    return code, response
+
+
+def main():
+    argument_spec = dict(task_id=dict(type="str"))
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+    code, response = get_task(module, connection)
+    if code == 200:
+        module.exit_json(ansible_facts=dict(checkpoint_tasks=response))
+    else:
+        module.fail_json(
+            msg="Checkpoint device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Checkpoint older modules written by Ansible, replacement of added modules weren't present in newly added `cp_mgmt_*` modules in Ansible `2.9`.

Please check it and if everything looks OK, we can merge these modules as the _run_script_ module is needed for log extraction. Also, the session module handles the discard of the session as well which current `cp_mgmt_publish` doesn't handle I believe.