### PR TITLE
Older Checkpoint modules with deprecation notice

### DIFF
--- a/plugins/modules/checkpoint_access_layer_facts.py
+++ b/plugins/modules/checkpoint_access_layer_facts.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["deprecated"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_access_layer_facts
+short_description: Get access layer facts on Check Point over Web Services API
+description:
+- Get access layer facts on Check Point devices. All operations are performed over
+  Web Services API.
+deprecated:
+  removed_in: '2.13'
+  alternative: cp_mgmt_access_layer_facts
+  why: Newer and updated modules released in Ansible 2.9
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  uid:
+    description:
+    - UID of access layer object.
+    type: str
+  name:
+    description:
+    - Name of the access layer object.
+    type: str
+"""
+
+EXAMPLES = """
+- name: Get object facts
+  checkpoint_access_layer_facts:
+"""
+
+RETURN = """
+ansible_facts:
+  description: The checkpoint access layer facts.
+  returned: always.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def get_access_layer(module, connection):
+    uid = module.params["uid"]
+    name = module.params["name"]
+
+    payload = {}
+
+    if uid:
+        payload = {"uid": uid}
+        code, result = connection.send_request(
+            "/web_api/show-access-layer", payload
+        )
+    elif name:
+        payload = {"name": name}
+        code, result = connection.send_request(
+            "/web_api/show-access-layer", payload
+        )
+    else:
+        code, result = connection.send_request(
+            "/web_api/show-access-layers", payload
+        )
+
+    return code, result
+
+
+def main():
+    argument_spec = dict(
+        uid=dict(type="str", default=None), name=dict(type="str", default=None)
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+
+    code, response = get_access_layer(module, connection)
+
+    if code == 200:
+        module.exit_json(ansible_facts=dict(checkpoint_access_layers=response))
+    else:
+        module.fail_json(
+            msg="Check Point device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_access_rule.py
+++ b/plugins/modules/checkpoint_access_rule.py
@@ -1,0 +1,312 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["deprecated"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_access_rule
+short_description: Manages access rules on Check Point over Web Services API
+description:
+- Manages access rules on Check Point devices including creating, updating, removing
+  access rules objects, All operations are performed over Web Services API.
+deprecated:
+  removed_in: '2.13'
+  alternative: cp_mgmt_access_rule
+  why: Newer and updated modules released in Ansible 2.9
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  name:
+    description:
+    - Name of the access rule.
+    type: str
+  layer:
+    description:
+    - Layer to attach the access rule to.
+    required: true
+    type: str
+  position:
+    description:
+    - Position of the access rule.
+    type: str
+  source:
+    description:
+    - Source object of the access rule.
+    type: str
+  destination:
+    description:
+    - Destination object of the access rule.
+    type: str
+  action:
+    description:
+    - Action of the access rule (accept, drop, inform, etc).
+    type: str
+    default: drop
+  enabled:
+    description:
+    - Enabled or disabled flag.
+    type: bool
+    default: true
+  state:
+    description:
+    - State of the access rule (present or absent). Defaults to present.
+    type: str
+    default: present
+  auto_publish_session:
+    description:
+    - Publish the current session if changes have been performed after task completes.
+    type: bool
+    default: 'yes'
+  auto_install_policy:
+    description:
+    - Install the package policy if changes have been performed after the task completes.
+    type: bool
+    default: 'yes'
+  policy_package:
+    description:
+    - Package policy name to be installed.
+    type: str
+    default: standard
+  targets:
+    description:
+    - Targets to install the package policy on.
+    type: list
+"""
+
+EXAMPLES = """
+- name: Create access rule
+  checkpoint_access_rule:
+    layer: Network
+    name: "Drop attacker"
+    position: top
+    source: attacker
+    destination: Any
+    action: Drop
+
+- name: Delete access rule
+  checkpoint_access_rule:
+    layer: Network
+    name: "Drop attacker"
+"""
+
+RETURN = """
+checkpoint_access_rules:
+  description: The checkpoint access rule object created or updated.
+  returned: always, except when deleting the access rule.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible_collections.checkpoint.checkpoint.plugins.module_utils.network.checkpoint.checkpoint import (
+    checkpoint_argument_spec,
+    publish,
+    install_policy,
+)
+
+
+def get_access_rule(module, connection):
+    name = module.params["name"]
+    layer = module.params["layer"]
+
+    payload = {"name": name, "layer": layer}
+
+    code, response = connection.send_request(
+        "/web_api/show-access-rule", payload
+    )
+
+    return code, response
+
+
+def create_access_rule(module, connection):
+    name = module.params["name"]
+    layer = module.params["layer"]
+    position = module.params["position"]
+    source = module.params["source"]
+    destination = module.params["destination"]
+    action = module.params["action"]
+
+    payload = {
+        "name": name,
+        "layer": layer,
+        "position": position,
+        "source": source,
+        "destination": destination,
+        "action": action,
+    }
+
+    code, response = connection.send_request(
+        "/web_api/add-access-rule", payload
+    )
+
+    return code, response
+
+
+def update_access_rule(module, connection):
+    name = module.params["name"]
+    layer = module.params["layer"]
+    position = module.params["position"]
+    source = module.params["source"]
+    destination = module.params["destination"]
+    action = module.params["action"]
+    enabled = module.params["enabled"]
+
+    payload = {
+        "name": name,
+        "layer": layer,
+        "position": position,
+        "source": source,
+        "destination": destination,
+        "action": action,
+        "enabled": enabled,
+    }
+
+    code, response = connection.send_request(
+        "/web_api/set-access-rule", payload
+    )
+
+    return code, response
+
+
+def delete_access_rule(module, connection):
+    name = module.params["name"]
+    layer = module.params["layer"]
+
+    payload = {"name": name, "layer": layer}
+
+    code, response = connection.send_request(
+        "/web_api/delete-access-rule", payload
+    )
+
+    return code, response
+
+
+def needs_update(module, access_rule):
+    res = False
+
+    if (
+        module.params["source"]
+        and module.params["source"] != access_rule["source"][0]["name"]
+    ):
+        res = True
+    if (
+        module.params["destination"]
+        and module.params["destination"]
+        != access_rule["destination"][0]["name"]
+    ):
+        res = True
+    if module.params["action"] != access_rule["action"]["name"]:
+        res = True
+    if module.params["enabled"] != access_rule["enabled"]:
+        res = True
+
+    return res
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str", required=True),
+        layer=dict(type="str"),
+        position=dict(type="str"),
+        source=dict(type="str"),
+        destination=dict(type="str"),
+        action=dict(type="str", default="drop"),
+        enabled=dict(type="bool", default=True),
+        state=dict(type="str", default="present"),
+    )
+    argument_spec.update(checkpoint_argument_spec)
+
+    required_if = [("state", "present", ("layer", "position"))]
+    module = AnsibleModule(
+        argument_spec=argument_spec, required_if=required_if
+    )
+    connection = Connection(module._socket_path)
+    code, response = get_access_rule(module, connection)
+    result = {"changed": False}
+
+    if module.params["state"] == "present":
+        if code == 200:
+            if needs_update(module, response):
+                code, response = update_access_rule(module, connection)
+                if code != 200:
+                    module.fail_json(msg=response)
+                if module.params["auto_publish_session"]:
+                    publish(connection)
+
+                    if module.params["auto_install_policy"]:
+                        install_policy(
+                            connection,
+                            module.params["policy_package"],
+                            module.params["targets"],
+                        )
+
+                result["changed"] = True
+                result["checkpoint_access_rules"] = response
+            else:
+                pass
+        elif code == 404:
+            code, response = create_access_rule(module, connection)
+            if code != 200:
+                module.fail_json(msg=response)
+            if module.params["auto_publish_session"]:
+                publish(connection)
+
+                if module.params["auto_install_policy"]:
+                    install_policy(
+                        connection,
+                        module.params["policy_package"],
+                        module.params["targets"],
+                    )
+
+            result["changed"] = True
+            result["checkpoint_access_rules"] = response
+    else:
+        if code == 200:
+            code, response = delete_access_rule(module, connection)
+            if code != 200:
+                module.fail_json(msg=response)
+            if module.params["auto_publish_session"]:
+                publish(connection)
+
+                if module.params["auto_install_policy"]:
+                    install_policy(
+                        connection,
+                        module.params["policy_package"],
+                        module.params["targets"],
+                    )
+
+            result["changed"] = True
+            result["checkpoint_access_rules"] = response
+        elif code == 404:
+            pass
+
+    result["checkpoint_session_uid"] = connection.get_session_uid()
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_access_rule_facts.py
+++ b/plugins/modules/checkpoint_access_rule_facts.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["deprecated"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_access_rule_facts
+short_description: Get access rules objects facts on Check Point over Web Services
+  API
+description:
+- Get access rules objects facts on Check Point devices. All operations are performed
+  over Web Services API.
+deprecated:
+  removed_in: '2.13'
+  alternative: cp_mgmt_access_rule_facts
+  why: Newer and updated modules released in Ansible 2.9
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  name:
+    description:
+    - Name of the access rule. If not provided, UID is required.
+    type: str
+  uid:
+    description:
+    - UID of the access rule. If not provided, name is required.
+    type: str
+  layer:
+    description:
+    - Layer the access rule is attached to.
+    required: true
+    type: str
+"""
+
+EXAMPLES = """
+- name: Get access rule facts
+  checkpoint_access_rule_facts:
+    layer: Network
+    name: "Drop attacker"
+"""
+
+RETURN = """
+ansible_facts:
+  description: The checkpoint access rule object facts.
+  returned: always.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def get_access_rule(module, connection):
+    name = module.params["name"]
+    uid = module.params["uid"]
+    layer = module.params["layer"]
+
+    if uid:
+        payload = {"uid": uid, "layer": layer}
+    elif name:
+        payload = {"name": name, "layer": layer}
+
+    code, response = connection.send_request(
+        "/web_api/show-access-rule", payload
+    )
+
+    return code, response
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str"),
+        uid=dict(type="str"),
+        layer=dict(type="str", required=True),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+    code, response = get_access_rule(module, connection)
+    if code == 200:
+        module.exit_json(ansible_facts=dict(checkpoint_access_rules=response))
+    else:
+        module.fail_json(
+            msg="Checkpoint device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_host.py
+++ b/plugins/modules/checkpoint_host.py
@@ -1,0 +1,232 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["deprecated"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_host
+short_description: Manages host objects on Check Point over Web Services API
+description:
+- Manages host objects on Check Point devices including creating, updating, removing
+  access rules objects. All operations are performed over Web Services API.
+deprecated:
+  removed_in: '2.13'
+  alternative: cp_mgmt_host
+  why: Newer and updated modules released in Ansible 2.9
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  name:
+    description:
+    - Name of the access rule.
+    type: str
+    required: true
+  ip_address:
+    description:
+    - IP address of the host object.
+    type: str
+  state:
+    description:
+    - State of the access rule (present or absent). Defaults to present.
+    type: str
+    default: present
+  auto_publish_session:
+    description:
+    - Publish the current session if changes have been performed after task completes.
+    type: bool
+    default: 'yes'
+  auto_install_policy:
+    description:
+    - Install the package policy if changes have been performed after the task completes.
+    type: bool
+    default: 'yes'
+  policy_package:
+    description:
+    - Package policy name to be installed.
+    type: str
+    default: standard
+  targets:
+    description:
+    - Targets to install the package policy on.
+    type: list
+"""
+
+EXAMPLES = """
+- name: Create host object
+  checkpoint_host:
+    name: attacker
+    ip_address: 192.168.0.15
+
+- name: Delete host object
+  checkpoint_host:
+    name: attacker
+    state: absent
+"""
+
+RETURN = """
+checkpoint_hosts:
+  description: The checkpoint host object created or updated.
+  returned: always, except when deleting the host.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible_collections.checkpoint.checkpoint.plugins.module_utils.network.checkpoint.checkpoint import (
+    checkpoint_argument_spec,
+    publish,
+    install_policy,
+)
+
+
+def get_host(module, connection):
+    name = module.params["name"]
+
+    payload = {"name": name}
+
+    code, response = connection.send_request("/web_api/show-host", payload)
+
+    return code, response
+
+
+def create_host(module, connection):
+    name = module.params["name"]
+    ip_address = module.params["ip_address"]
+
+    payload = {"name": name, "ip-address": ip_address}
+
+    code, response = connection.send_request("/web_api/add-host", payload)
+
+    return code, response
+
+
+def update_host(module, connection):
+    name = module.params["name"]
+    ip_address = module.params["ip_address"]
+
+    payload = {"name": name, "ip-address": ip_address}
+
+    code, response = connection.send_request("/web_api/set-host", payload)
+
+    return code, response
+
+
+def delete_host(module, connection):
+    name = module.params["name"]
+
+    payload = {"name": name}
+
+    code, response = connection.send_request("/web_api/delete-host", payload)
+
+    return code, response
+
+
+def needs_update(module, host):
+    res = False
+
+    if module.params["ip_address"] != host["ipv4-address"]:
+        res = True
+
+    return res
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str", required=True),
+        ip_address=dict(type="str"),
+        state=dict(type="str", default="present"),
+    )
+    argument_spec.update(checkpoint_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+    code, response = get_host(module, connection)
+    result = {"changed": False}
+
+    if module.params["state"] == "present":
+        if code == 200:
+            if needs_update(module, response):
+                code, response = update_host(module, connection)
+                if code != 200:
+                    module.fail_json(msg=response)
+                if module.params["auto_publish_session"]:
+                    publish(connection)
+
+                    if module.params["auto_install_policy"]:
+                        install_policy(
+                            connection,
+                            module.params["policy_package"],
+                            module.params["targets"],
+                        )
+
+                result["changed"] = True
+                result["checkpoint_hosts"] = response
+            else:
+                pass
+        elif code == 404:
+            code, response = create_host(module, connection)
+            if code != 200:
+                module.fail_json(msg=response)
+            if module.params["auto_publish_session"]:
+                publish(connection)
+
+                if module.params["auto_install_policy"]:
+                    install_policy(
+                        connection,
+                        module.params["policy_package"],
+                        module.params["targets"],
+                    )
+
+            result["changed"] = True
+            result["checkpoint_hosts"] = response
+    else:
+        if code == 200:
+            # Handle deletion
+            code, response = delete_host(module, connection)
+            if code != 200:
+                module.fail_json(msg=response)
+            if module.params["auto_publish_session"]:
+                publish(connection)
+
+                if module.params["auto_install_policy"]:
+                    install_policy(
+                        connection,
+                        module.params["policy_package"],
+                        module.params["targets"],
+                    )
+
+            result["changed"] = True
+            result["checkpoint_hosts"] = response
+        elif code == 404:
+            pass
+
+    result["checkpoint_session_uid"] = connection.get_session_uid()
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_host_facts.py
+++ b/plugins/modules/checkpoint_host_facts.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["deprecated"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_host_facts
+short_description: Get host objects facts on Check Point over Web Services API
+description:
+- Get host objects facts on Check Point devices. All operations are performed over
+  Web Services API.
+deprecated:
+  removed_in: '2.13'
+  alternative: cp_mgmt_host_facts
+  why: Newer and updated modules released in Ansible 2.9
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  name:
+    description:
+    - Name of the host object. If name is not provided, UID is required.
+    type: str
+  uid:
+    description:
+    - UID of the host object. If UID is not provided, name is required.
+    type: str
+"""
+
+EXAMPLES = """
+- name: Get host object facts
+  checkpoint_host_facts:
+    name: attacker
+"""
+
+RETURN = """
+ansible_hosts:
+  description: The checkpoint host object facts.
+  returned: always.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def get_host(module, connection):
+    name = module.params["name"]
+    uid = module.params["uid"]
+
+    if uid:
+        payload = {"uid": uid}
+    elif name:
+        payload = {"name": name}
+
+    code, result = connection.send_request("/web_api/show-host", payload)
+
+    return code, result
+
+
+def main():
+    argument_spec = dict(name=dict(type="str"), uid=dict(type="str"))
+
+    required_one_of = [("name", "uid")]
+    module = AnsibleModule(
+        argument_spec=argument_spec, required_one_of=required_one_of
+    )
+    connection = Connection(module._socket_path)
+
+    code, response = get_host(module, connection)
+
+    if code == 200:
+        module.exit_json(ansible_facts=dict(checkpoint_hosts=response))
+    else:
+        module.fail_json(
+            msg="Checkpoint device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_object_facts.py
+++ b/plugins/modules/checkpoint_object_facts.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "network",
+}
+
+
+DOCUMENTATION = """module: checkpoint_object_facts
+short_description: Get object facts on Check Point over Web Services API
+description:
+- Get object facts on Check Point devices. All operations are performed over Web Services
+  API.
+author: Ansible by Red Hat (@rcarrillocruz)
+options:
+  uid:
+    description:
+    - UID of the object. If UID is not provided, it will do a full search which can
+      be filtered with the filter argument.
+  object_filter:
+    description:
+    - Filter expression for search. It accepts AND/OR logical operators and performs
+      a textual and IP address search. To search only by IP address, set ip_only argument
+      to True. which can be filtered with the filter argument.
+  ip_only:
+    description:
+    - Filter only by IP address.
+    type: bool
+    default: false
+  object_type:
+    description:
+    - Type of the object to search. Must be a valid API resource name
+    type: str
+"""
+
+EXAMPLES = """
+- name: Get object facts
+  checkpoint_object_facts:
+    object_filter: 192.168.30.30
+    ip_only: yes
+"""
+
+RETURN = """
+ansible_hosts:
+  description: The checkpoint object facts.
+  returned: always.
+  type: list
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+
+
+def get_object(module, connection):
+    uid = module.params["uid"]
+    object_filter = module.params["object_filter"]
+    ip_only = module.params["ip_only"]
+    object_type = module.params["object_type"]
+
+    if uid:
+        payload = {"uid": uid}
+        code, result = connection.send_request("/web_api/show-object", payload)
+    else:
+        payload = {
+            "filter": object_filter,
+            "ip-only": ip_only,
+            "type": object_type,
+        }
+        code, result = connection.send_request(
+            "/web_api/show-objects", payload
+        )
+
+    return code, result
+
+
+def main():
+    argument_spec = dict(
+        uid=dict(type="str", default=None),
+        object_filter=dict(type="str", default=None),
+        ip_only=dict(type="bool", default=False),
+        object_type=dict(type="str", default=None),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+    connection = Connection(module._socket_path)
+
+    code, response = get_object(module, connection)
+
+    if code == 200:
+        module.exit_json(ansible_facts=dict(checkpoint_objects=response))
+    else:
+        module.fail_json(
+            msg="Check Point device returned error {0} with message {1}".format(
+                code, response
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/checkpoint_session.py
+++ b/plugins/modules/checkpoint_session.py
@@ -23,7 +23,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",
-    "status": ["preview"],
+    "status": ["deprecated"],
     "supported_by": "network",
 }
 
@@ -33,6 +33,10 @@ short_description: Manages session objects on Check Point over Web Services API
 description:
 - Manages session objects on Check Point devices performing actions like publish and
   discard. All operations are performed over Web Services API.
+deprecated:
+  removed_in: '2.13'
+  alternative: cp_mgmt_publish and cp_mgmt_discard
+  why: Newer and updated modules released in Ansible 2.9
 version_added: "2.7"
 author: Ansible by Red Hat (@rcarrillocruz)
 options:


### PR DESCRIPTION
Older Checkpoint modules which have a newer alternative available with Ansible 2.9 release. Older checkpoint modules are also updated with their deprecation notice.

cc. @chkp-orso 