### PR TITLE
Capture and return "run-script" command output

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -213,6 +213,7 @@ def api_command(module, command):
                     if 'task-id' in task:
                         task_id = task['task-id']
                         response[task_id] = wait_for_task(module, version, connection, task['task-id'])
+                del response['tasks']
 
         result[command] = response
     else:

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -211,7 +211,8 @@ def api_command(module, command):
             elif 'tasks' in response:
                 for task in response['tasks']:
                     if 'task-id' in task:
-                        wait_for_task(module, version, connection, task['task-id'])
+                        task_id = task['task-id']
+                        response[task_id] = wait_for_task(module, version, connection, task['task-id'])
 
         result[command] = response
     else:


### PR DESCRIPTION
Hi,

when calling "run-script" with the attached playbook, the return value doesn't contain the command output.

```
---
- hosts: check_point_manager
  gather_facts: no
  connection: httpapi

  tasks:
    - name: show hostname
      check_point.mgmt.cp_mgmt_run_script:
        script: 'clish -c "show hostname"'
        script_name: 'show hostname'
        wait_for_task: yes
        targets:
          - fw-cp1
          - fw-cp2
      register: cp_mgmt_run_script

    - debug: var=cp_mgmt_run_script
```

This commit should fix this.

Regards,
Alex