### PR TITLE
Api command fixes

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -536,7 +536,7 @@ def api_command(module, command):
     if command.startswith("show"):
         result['changed'] = False
 
-    if code == 200:
+    if code == 200 and "incidents" not in response:
         if module.params["wait_for_task"]:
             if "task-id" in response:
                 response = wait_for_task(

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -536,7 +536,7 @@ def api_command(module, command):
     if command.startswith("show"):
         result['changed'] = False
 
-    if code == 200 and "incidents" not in response:
+    if code == 200:
         if module.params["wait_for_task"]:
             if "task-id" in response:
                 response = wait_for_task(

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -532,6 +532,9 @@ def api_command(module, command):
 
     code, response = send_request(connection, version, command, payload)
     result = {"changed": True}
+    
+    if command.startswith("show"):
+        result['changed'] = False
 
     if code == 200:
         if module.params["wait_for_task"]:


### PR DESCRIPTION
Fixes 2 bugs in the api_command function.
API-command staring with "show" now set the "changed" flag to false.
Also API-responses containig "incidents" (errors handled by the underlying checkpoint) now raise exceptions.