### PR TITLE
Cleaned up unused import call to ansible.module_utils.connection

### DIFF
--- a/plugins/modules/cp_mgmt_access_rules.py
+++ b/plugins/modules/cp_mgmt_access_rules.py
@@ -300,7 +300,7 @@ cp_mgmt_access_rules:
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.connection import Connection
+''' from ansible.module_utils.connection import Connection '''  # Removing this line due to pylint error. this module is not being used.
 from ansible_collections.check_point.mgmt.plugins.module_utils.checkpoint import (
     checkpoint_argument_spec_for_action_module,
 )


### PR DESCRIPTION
One file needed to be modified. 
There was an unnecessary import call to ansible.module_utils.connection.
I commented out the line and added an inline comment regarding the modification made. 