### PR TITLE
Fix api_command() failure handling

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -564,7 +564,10 @@ def api_command(module, command):
 
         handle_publish(module, connection, version)
     else:
-        discard_and_fail(module, code, response, connection, version)
+        if command.startswith("show"):
+            module.fail_json(msg=parse_fail_message(code, response))
+        else:
+            discard_and_fail(module, code, response, connection, version)
 
     return result
 


### PR DESCRIPTION
Fix api_command() failure handling: for other-than-200 http code, if command is 'show-..', then return Ansible module.fail_json instead of discard_and_fail. All others still discard_and_fail.