### PR TITLE
Fix logic error in call_is_plural() for access-rule vs. access-rulebase, etc.

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1405,12 +1405,16 @@ def api_call_for_rule(module, api_call_object):
 
 # check if call is in plural form
 def call_is_plural(api_call_object, payload):
-    if payload.get("name") is not None or payload.get("rule-number") is not None and \
-            ("nat" in api_call_object or "mobile-access" in api_call_object):
+    if (
+        (payload.get("name") is not None or payload.get("rule-number") is not None)
+        and ("nat" in api_call_object or "mobile-access" in api_call_object)
+    ):
         return False
-    if payload.get("layer") is None and \
-            ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object):
-        return True
+    if (
+        payload.get("layer") is None
+        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
+    ):
+       return True
     return False
 
 


### PR DESCRIPTION
The inline "or" clause breaks the evaluation and always returns False. Grouping added around the "or" portion fixes this.
Code style also adjusted to be equivalent to other similar multi-conditional groupings.