### PR TITLE
Add test for 'nat' for plural version of api call when nat-rulebase is used

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1405,12 +1405,16 @@ def api_call_for_rule(module, api_call_object):
 
 # check if call is in plural form
 def call_is_plural(api_call_object, payload):
-    if payload.get("name") is not None or payload.get("rule-number") is not None and \
-            ("nat" in api_call_object or "mobile-access" in api_call_object):
+    if (
+        (payload.get("name") is not None or payload.get("rule-number") is not None)
+        and ("nat" in api_call_object or "mobile-access" in api_call_object)
+    ):
         return False
-    if payload.get("layer") is None and \
-            ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object):
-        return True
+    if (
+        payload.get("layer") is None
+        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
+    ):
+       return True
     return False
 
 

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1412,7 +1412,8 @@ def call_is_plural(api_call_object, payload):
         return False
     if (
         payload.get("layer") is None
-        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
+        and ("access" in api_call_object or "threat" in api_call_object
+             or "https" in api_call_object or "nat" in api_call_object)
     ):
        return True
     return False


### PR DESCRIPTION
Add test in call_is_plural() to return true when 'nat-rulebase' is wanted versus nat-rule
Tested and verified.