### PR TITLE
Add test for 'nat' in call_is_plural() to allow for nat-rulebase

### DIFF
--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1405,12 +1405,16 @@ def api_call_for_rule(module, api_call_object):
 
 # check if call is in plural form
 def call_is_plural(api_call_object, payload):
-    if payload.get("name") is not None or payload.get("rule-number") is not None and \
-            ("nat" in api_call_object or "mobile-access" in api_call_object):
+    if (
+        (payload.get("name") is not None or payload.get("rule-number") is not None)
+        and ("nat" in api_call_object or "mobile-access" in api_call_object)
+    ):
         return False
-    if payload.get("layer") is None and \
-            ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object):
-        return True
+    if (
+        payload.get("layer") is None
+        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
+    ):
+       return True
     return False
 
 

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1415,7 +1415,8 @@ def call_is_plural(api_call_object, payload):
         return False
     if (
         payload.get("layer") is None
-        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
+        and ("access" in api_call_object or "threat" in api_call_object
+             or "https" in api_call_object or "nat" in api_call_object)
     ):
        return True
     return False

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1412,8 +1412,7 @@ def call_is_plural(api_call_object, payload):
         return False
     if (
         payload.get("layer") is None
-        and ("access" in api_call_object or "threat" in api_call_object
-             or "https" in api_call_object or "nat" in api_call_object)
+        and ("access" in api_call_object or "threat" in api_call_object)
     ):
        return True
     return False

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1412,7 +1412,8 @@ def call_is_plural(api_call_object, payload):
         return False
     if (
         payload.get("layer") is None
-        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
+        and ("access" in api_call_object or "threat" in api_call_object
+             or "https" in api_call_object or "nat" in api_call_object)
     ):
        return True
     return False

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -1415,7 +1415,7 @@ def call_is_plural(api_call_object, payload):
         return False
     if (
         payload.get("layer") is None
-        and ("access" in api_call_object or "threat" in api_call_object)
+        and ("access" in api_call_object or "threat" in api_call_object or "https" in api_call_object)
     ):
        return True
     return False

--- a/plugins/module_utils/checkpoint.py
+++ b/plugins/module_utils/checkpoint.py
@@ -564,7 +564,10 @@ def api_command(module, command):
 
         handle_publish(module, connection, version)
     else:
-        discard_and_fail(module, code, response, connection, version)
+        if command.startswith("show"):
+            module.fail_json(msg=parse_fail_message(code, response))
+        else:
+            discard_and_fail(module, code, response, connection, version)
 
     return result
 


### PR DESCRIPTION
Add test for 'nat' in api_call_object to support nat-rulebase vs nat-rule when using cp_mgmt_nat_rule_facts module.

Not sure why the PR can't automatically merge, tho. Re-synced the repo, pulled, and merged.  Dunno why GitHub is complaining.