### PR TITLE
Fix: Don't request /web_api/logout without X-chkp-sid

### DIFF
--- a/plugins/httpapi/checkpoint.py
+++ b/plugins/httpapi/checkpoint.py
@@ -87,6 +87,11 @@ class HttpApi(HttpApiBase):
             self.connection._session_uid = response_data["uid"]
 
     def logout(self):
+        if any([
+            not self.connection._auth,
+            (self.connection._auth and "X-chkp-sid" not in self.connection._auth)
+        ]):
+            return
         url = "/web_api/logout"
 
         response, dummy = self.send_request(url, None)


### PR DESCRIPTION
This is to prevent the logout function from making a call to `/web_api/logout` when there is no auth header `X-chkp-sid`. 